### PR TITLE
Optimize stationsNearPath query

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,7 +15,8 @@
         "express": "^4.18.2",
         "firebase-admin": "^11.6.0",
         "mysql": "^2.18.1",
-        "nodemon": "^2.0.20"
+        "nodemon": "^2.0.20",
+        "simplify-js": "^1.2.4"
       },
       "devDependencies": {
         "eslint": "^8.38.0",
@@ -7248,6 +7249,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/simplify-js": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/simplify-js/-/simplify-js-1.2.4.tgz",
+      "integrity": "sha512-vITfSlwt7h/oyrU42R83mtzFpwYk3+mkH9bOHqq/Qw6n8rtR7aE3NZQ5fbcyCUVVmuMJR6ynsAhOfK2qoah8Jg=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,8 @@
     "express": "^4.18.2",
     "firebase-admin": "^11.6.0",
     "mysql": "^2.18.1",
-    "nodemon": "^2.0.20"
+    "nodemon": "^2.0.20",
+    "simplify-js": "^1.2.4"
   },
   "devDependencies": {
     "eslint": "^8.38.0",


### PR DESCRIPTION
Install `simplify.js` to simplify the complicated waypoints.

Adapt `ST_DISTANCE()` in MySQL to directly obtain the point-to-line distance.

Now it takes only 5 secs to query on a path from Philadelphia to Seattle.