### PR TITLE
Fix location null issue in popup; Show only electric stations on the map

### DIFF
--- a/client/src/common/APIUtils.js
+++ b/client/src/common/APIUtils.js
@@ -3,14 +3,19 @@ import axios from "axios";
 const config = require("../config.json");
 
 // eslint-disable-next-line import/prefer-default-export
-export const getNearbyStations = async (location, maxDistance) => {
+export const getNearbyStations = async (
+  location,
+  maxDistance,
+  isElectric = false
+) => {
   if (!location || !location.latitude || !location.longitude) {
     return [];
   }
 
   try {
     const response = await axios.get(
-      `http://${config.server_host}:${config.server_port}/stations` +
+      `http://${config.server_host}:${config.server_port}/stations/` +
+        `${isElectric ? "electric/" : ""}` +
         `?latitude=${location.latitude}&longitude=${location.longitude}` +
         `&mileDistance=${maxDistance}&pageSize=${150}`
     );

--- a/client/src/home/Map.js
+++ b/client/src/home/Map.js
@@ -47,7 +47,8 @@ export default function Map({ curLocation, stations }) {
       mapboxApiAccessToken={MAPBOX_TOKEN}
     >
       {Array.isArray(stations) &&
-        stations?.map((station) => (
+        stations.length > 0 &&
+        stations.map((station) => (
           <Marker
             latitude={station.location.y}
             longitude={station.location.x}

--- a/client/src/home/index.js
+++ b/client/src/home/index.js
@@ -38,15 +38,17 @@ export default function HomePage() {
   const [path, setPath] = useState([]);
 
   useEffect(() => {
-    getNearbyStations(curLocation, maxDistance).then((response) => {
-      setStations(response);
-      if (!response || response.length === 0) {
-        setStationFormError(true);
-        setStationFormErrorText(
-          "No stations found within the specified distance and location. Please try again with a different distance or location."
-        );
+    getNearbyStations(curLocation, maxDistance, { isElectric: true }).then(
+      (response) => {
+        setStations(response);
+        if (!response || response.length === 0) {
+          setStationFormError(true);
+          setStationFormErrorText(
+            "No stations found within the specified distance and location. Please try again with a different distance or location."
+          );
+        }
       }
-    });
+    );
   }, [curLocation]);
 
   const handleStationInputSubmit = async () => {

--- a/client/src/popups/StationPopup.js
+++ b/client/src/popups/StationPopup.js
@@ -161,8 +161,8 @@ function StationPopup({ open, handleClose, stationId }) {
             <NearbyRestaurantsPopup
               open={nearbyRestaurantsOpen}
               handleClose={handleNearbyRestaurantsClose}
-              longitude={stationData.location.x}
-              latitude={stationData.location.y}
+              longitude={stationData.location?.x}
+              latitude={stationData.location?.y}
             />
           </DialogActions>
         </>


### PR DESCRIPTION
The corner case happens due to the fact that stations showing on the map were not necessarily electric stations but were querying /stations/electric in StationPopup