### PR TITLE
Header and footer

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import PropTypes from "prop-types";
 import { AuthProvider } from "./auth/AuthContext";
 import WithAuthRedirect from "./common/WithAuthRedirect";
+import Layout from "./common/Layout";
 import Landing from "./landingPage";
 import Login from "./auth/Login";
 import Signup from "./auth/Signup";
@@ -16,30 +17,32 @@ function App({ toggleTheme }) {
   return (
     <Router>
       <AuthProvider>
-        <Routes>
-          <Route
-            exact
-            path="/"
-            element={<Landing toggleTheme={toggleTheme} />}
-          />
-          <Route path="/login" element={<Login />} />
-          <Route path="/signup" element={<Signup />} />
-          <Route path="/forgot-password" element={<ForgotPassword />} />
-          <Route path="/home" element={<HomePage />} />
-          <Route path="/popup-test" element={<PopupTest />} />
-          <Route
-            path="/statistics"
-            element={<Statistics toggleTheme={toggleTheme} />}
-          />
-          <Route
-            path="/settings"
-            element={
-              <WithAuthRedirect>
-                <Settings />
-              </WithAuthRedirect>
-            }
-          />
-        </Routes>
+        <Layout>
+          <Routes>
+            <Route
+              exact
+              path="/"
+              element={<Landing toggleTheme={toggleTheme} />}
+            />
+            <Route path="/login" element={<Login />} />
+            <Route path="/signup" element={<Signup />} />
+            <Route path="/forgot-password" element={<ForgotPassword />} />
+            <Route path="/home" element={<HomePage />} />
+            <Route path="/popup-test" element={<PopupTest />} />
+            <Route
+              path="/statistics"
+              element={<Statistics toggleTheme={toggleTheme} />}
+            />
+            <Route
+              path="/settings"
+              element={
+                <WithAuthRedirect>
+                  <Settings />
+                </WithAuthRedirect>
+              }
+            />
+          </Routes>
+        </Layout>
       </AuthProvider>
     </Router>
   );

--- a/client/src/common/AppBar.js
+++ b/client/src/common/AppBar.js
@@ -1,0 +1,245 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import AppBar from "@mui/material/AppBar";
+import Box from "@mui/material/Box";
+import Toolbar from "@mui/material/Toolbar";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import Menu from "@mui/material/Menu";
+import MenuIcon from "@mui/icons-material/Menu";
+import Container from "@mui/material/Container";
+import AccountCircle from "@mui/icons-material/AccountCircle";
+import Button from "@mui/material/Button";
+import Tooltip from "@mui/material/Tooltip";
+import MenuItem from "@mui/material/MenuItem";
+import Snackbar from "@mui/material/Snackbar";
+import Alert from "@mui/material/Alert";
+import OfflineBoltIcon from "@mui/icons-material/OfflineBolt";
+import { useTheme } from "@mui/material/styles";
+import { useAuth } from "../auth/AuthContext";
+
+const pages = ["Home", "Statistics"];
+const settings = ["Settings", "Logout"];
+
+function ResponsiveAppBar() {
+  const [anchorElNav, setAnchorElNav] = useState(null);
+  const [anchorElUser, setAnchorElUser] = useState(null);
+
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
+
+  const myTheme = useTheme();
+  const navigate = useNavigate();
+
+  const handleOpenNavMenu = (event) => {
+    setAnchorElNav(event.currentTarget);
+  };
+  const handleOpenUserMenu = (event) => {
+    setAnchorElUser(event.currentTarget);
+  };
+
+  const handleCloseNavMenu = () => {
+    setAnchorElNav(null);
+  };
+
+  const handleCloseUserMenu = () => {
+    setAnchorElUser(null);
+  };
+
+  const handleLoginClick = () => {
+    navigate("/login");
+    handleCloseNavMenu();
+  };
+
+  const { currentUser, logout } = useAuth();
+
+  // Log out the current user and navigate to the login page
+  const handleLogout = async () => {
+    try {
+      await logout();
+      navigate("/login");
+    } catch (logoutError) {
+      setSnackbarMessage(`Failed to log out. ${logoutError.message}`);
+      setSnackbarOpen(true);
+    }
+    setAnchorElUser(null);
+  };
+
+  return (
+    <>
+      <AppBar position="static">
+        <Container maxWidth="false">
+          <Toolbar disableGutters>
+            <OfflineBoltIcon
+              sx={{ display: { xs: "none", md: "flex" }, mr: 1 }}
+            />
+            <Typography
+              variant="h6"
+              noWrap
+              component="a"
+              href="/"
+              sx={{
+                mr: 2,
+                display: { xs: "none", md: "flex" },
+                fontFamily: "monospace",
+                fontWeight: 700,
+                letterSpacing: ".2rem",
+                color: "inherit",
+                textDecoration: "none",
+              }}
+            >
+              JuiceFinder
+            </Typography>
+
+            <Box sx={{ flexGrow: 1, display: { xs: "flex", md: "none" } }}>
+              <IconButton
+                size="large"
+                aria-label="account of current user"
+                aria-controls="menu-appbar"
+                aria-haspopup="true"
+                onClick={handleOpenNavMenu}
+                color="inherit"
+              >
+                <MenuIcon />
+              </IconButton>
+              <Menu
+                id="menu-appbar"
+                anchorEl={anchorElNav}
+                anchorOrigin={{
+                  vertical: "bottom",
+                  horizontal: "left",
+                }}
+                keepMounted
+                transformOrigin={{
+                  vertical: "top",
+                  horizontal: "left",
+                }}
+                open={Boolean(anchorElNav)}
+                onClose={handleCloseNavMenu}
+                sx={{
+                  display: { xs: "block", md: "none" },
+                }}
+              >
+                {pages.map((page) => (
+                  <MenuItem key={page} onClick={handleCloseNavMenu}>
+                    <Typography textAlign="center">{page}</Typography>
+                  </MenuItem>
+                ))}
+              </Menu>
+            </Box>
+            <OfflineBoltIcon
+              sx={{ display: { xs: "flex", md: "none" }, mr: 1 }}
+            />
+            <Typography
+              variant="h5"
+              noWrap
+              component="a"
+              href=""
+              sx={{
+                mr: 2,
+                display: { xs: "flex", md: "none" },
+                flexGrow: 1,
+                fontFamily: "monospace",
+                fontWeight: 700,
+                letterSpacing: ".3rem",
+                color: "inherit",
+                textDecoration: "none",
+              }}
+            >
+              JuiceFinder
+            </Typography>
+            <Box sx={{ flexGrow: 1, display: { xs: "none", md: "flex" } }}>
+              {pages.map((page) => (
+                <Button
+                  key={page}
+                  onClick={handleCloseNavMenu}
+                  sx={{
+                    my: 2,
+                    color: myTheme.palette.primary.contrastText,
+                    display: "block",
+                  }}
+                >
+                  <Link
+                    to={`/${page.toLowerCase()}`}
+                    style={{ textDecoration: "none", color: "inherit" }}
+                  >
+                    {page}
+                  </Link>
+                </Button>
+              ))}
+            </Box>
+
+            <Box sx={{ flexGrow: 0 }}>
+              {currentUser ? (
+                <>
+                  <Tooltip title="Open settings">
+                    <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
+                      <AccountCircle color="secondary" />
+                    </IconButton>
+                  </Tooltip>
+                  <Menu
+                    sx={{ mt: "45px" }}
+                    id="menu-appbar"
+                    anchorEl={anchorElUser}
+                    anchorOrigin={{
+                      vertical: "top",
+                      horizontal: "right",
+                    }}
+                    keepMounted
+                    transformOrigin={{
+                      vertical: "top",
+                      horizontal: "right",
+                    }}
+                    open={Boolean(anchorElUser)}
+                    onClose={handleCloseUserMenu}
+                  >
+                    {settings.map((setting) => (
+                      <MenuItem
+                        key={setting}
+                        onClick={
+                          setting === "Logout"
+                            ? handleLogout
+                            : handleCloseUserMenu
+                        }
+                        component={setting === "Logout" ? "div" : Link}
+                        to={
+                          setting !== "Logout"
+                            ? `/${setting.toLowerCase()}`
+                            : undefined
+                        }
+                      >
+                        <Typography textAlign="center">{setting}</Typography>
+                      </MenuItem>
+                    ))}
+                  </Menu>
+                </>
+              ) : (
+                <Button
+                  onClick={handleLoginClick}
+                  sx={{
+                    my: 2,
+                    color: myTheme.palette.primary.contrastText,
+                    display: "block",
+                  }}
+                >
+                  Login
+                </Button>
+              )}
+            </Box>
+          </Toolbar>
+        </Container>
+      </AppBar>
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={6000}
+        onClose={() => setSnackbarOpen(false)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      >
+        <Alert onClose={() => setSnackbarOpen(false)} severity="error">
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}
+export default ResponsiveAppBar;

--- a/client/src/common/Footer.js
+++ b/client/src/common/Footer.js
@@ -1,0 +1,86 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Box from "@mui/material/Box";
+import { Typography } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+
+function CircleButton({ initials, URL }) {
+  const myTheme = useTheme();
+
+  return (
+    <a
+      href={URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{ textDecoration: "none", color: "inherit" }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: myTheme.palette.secondary.contrastText,
+          backgroundColor: myTheme.palette.secondary.main,
+          "&:hover": {
+            backgroundColor: myTheme.palette.secondary.light,
+          },
+          borderRadius: "50%",
+          width: "26px",
+          height: "26px",
+          marginRight: "8px",
+        }}
+      >
+        <Typography variant="body2" color="inherit">
+          {initials}
+        </Typography>
+      </Box>
+    </a>
+  );
+}
+CircleButton.propTypes = {
+  initials: PropTypes.string.isRequired,
+  URL: PropTypes.string.isRequired,
+};
+
+function Footer() {
+  const myTheme = useTheme();
+
+  return (
+    <Box
+      sx={{
+        height: "15px",
+        pt: myTheme.spacing(2),
+        pb: myTheme.spacing(2),
+        backgroundColor: myTheme.palette.primary.main,
+        color: myTheme.palette.primary.contrastText,
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        width: "100%",
+      }}
+    >
+      <Typography variant="body1" align="left" sx={{ ml: myTheme.spacing(3) }}>
+        Copyright © {new Date().getFullYear()} JuiceFinder
+      </Typography>
+      <Box
+        sx={{ display: "flex", alignItems: "center", mr: myTheme.spacing(3) }}
+      >
+        <Typography
+          variant="body1"
+          sx={{ display: "inline", mr: myTheme.spacing(1) }}
+        >
+          Contributors:
+        </Typography>
+        <CircleButton
+          initials="CL"
+          URL="https://github.com/AdvisorChuanChuan"
+        />
+        <CircleButton initials="WL" URL="https://github.com/lewei22" />
+        <CircleButton initials="YS" URL="https://www.yichengshen.com" />
+        <CircleButton initials="ZL" URL="https://github.com/lizyn" />
+      </Box>
+    </Box>
+  );
+}
+
+export default Footer;

--- a/client/src/common/Layout.js
+++ b/client/src/common/Layout.js
@@ -1,0 +1,21 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import PropTypes from "prop-types";
+import Footer from "./Footer";
+import ResponsiveAppBar from "./AppBar";
+
+function Layout({ children }) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}>
+      <ResponsiveAppBar />
+      <Box sx={{ minHeight: "calc(100% - 15px)", flexGrow: 1 }}>{children}</Box>
+      <Footer />
+    </Box>
+  );
+}
+
+Layout.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Layout;

--- a/client/src/home/index.js
+++ b/client/src/home/index.js
@@ -7,6 +7,7 @@ import {
   getCoordinatesFromAddress,
   getStationsNearPath,
 } from "../common/APIUtils";
+import ResponsiveAppBar from "../common/AppBar";
 
 export default function HomePage() {
   const DEFAULT_LOCATION = {
@@ -95,6 +96,7 @@ export default function HomePage() {
 
   return (
     <div style={{ height: "100vh", width: "100vw" }}>
+      <ResponsiveAppBar />
       <Box
         sx={{
           display: "grid",

--- a/client/src/home/index.js
+++ b/client/src/home/index.js
@@ -7,7 +7,6 @@ import {
   getCoordinatesFromAddress,
   getStationsNearPath,
 } from "../common/APIUtils";
-import ResponsiveAppBar from "../common/AppBar";
 
 export default function HomePage() {
   const DEFAULT_LOCATION = {
@@ -95,13 +94,11 @@ export default function HomePage() {
   };
 
   return (
-    <div style={{ height: "100vh", width: "100vw" }}>
-      <ResponsiveAppBar />
+    <div style={{ width: "100vw" }}>
       <Box
         sx={{
           display: "grid",
           gridTemplateColumns: "1fr 4fr",
-          height: "100%",
         }}
       >
         <Box

--- a/client/src/settings/index.js
+++ b/client/src/settings/index.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 import csvtojson from "csvtojson";
-import { useNavigate } from "react-router-dom";
 import { useTheme } from "@mui/material/styles";
 import {
   Box,
@@ -28,11 +27,9 @@ const StyledContainer = styled(Container)(() => ({
 
 function Settings() {
   const theme = useTheme();
-  const navigate = useNavigate();
 
-  const { currentUser, logout } = useAuth();
+  const { currentUser } = useAuth();
   const [errorMsg, setErrorMsg] = useState("");
-  const [loading, setLoading] = useState(false);
 
   const [vehicleId, setVehicleId] = useState("");
   const [vehicleInfo, setVehicleInfo] = useState(null);
@@ -178,20 +175,6 @@ function Settings() {
   useEffect(() => {
     fetchVehicleInfo();
   }, [currentUser, vehicleId]);
-
-  // Log out the current user and navigate to the login page
-  const handleLogout = async () => {
-    setErrorMsg("");
-    setLoading(true);
-    try {
-      await logout();
-      navigate("/login");
-    } catch (logoutError) {
-      setErrorMsg(`Failed to log out. ${logoutError.message}`);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   // Update the vehicle information based on the provided vehicle ID and re-fetch the updated information
   const updateVehicle = async () => {
@@ -471,16 +454,6 @@ function Settings() {
             </DialogContent>
           </Dialog>
         </div>
-
-        <Button
-          variant="contained"
-          color="primary"
-          disabled={loading}
-          onClick={handleLogout}
-          sx={{ marginTop: theme.spacing(2) }}
-        >
-          Logout (for testing)
-        </Button>
       </StyledContainer>
     </>
   );

--- a/client/src/settings/index.js
+++ b/client/src/settings/index.js
@@ -17,7 +17,6 @@ import OfflineBoltIcon from "@mui/icons-material/OfflineBolt";
 import { styled } from "@mui/system";
 import { useAuth } from "../auth/AuthContext";
 import config from "../config.json";
-import ResponsiveAppBar from "../common/AppBar";
 
 const StyledContainer = styled(Container)(() => ({
   display: "flex",
@@ -221,241 +220,238 @@ function Settings() {
   };
 
   return (
-    <>
-      <ResponsiveAppBar />
-      <StyledContainer
-        maxWidth="md"
+    <StyledContainer
+      maxWidth="md"
+      sx={{
+        marginTop: theme.spacing(2),
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        backgroundColor: theme.palette.background.paper,
+        borderRadius: theme.shape.borderRadius,
+        paddingTop: theme.spacing(6),
+        paddingBottom: theme.spacing(10),
+        paddingLeft: theme.spacing(6),
+        paddingRight: theme.spacing(6),
+        boxShadow: theme.shadows[3],
+      }}
+    >
+      <Typography
+        component="h1"
+        variant="h3"
+        color="primary"
+        sx={{ textAlign: "center" }}
+      >
+        JuiceFinder
+      </Typography>
+      <Avatar
         sx={{
-          marginTop: theme.spacing(2),
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          backgroundColor: theme.palette.background.paper,
-          borderRadius: theme.shape.borderRadius,
-          paddingTop: theme.spacing(6),
-          paddingBottom: theme.spacing(10),
-          paddingLeft: theme.spacing(6),
-          paddingRight: theme.spacing(6),
-          boxShadow: theme.shadows[3],
+          margin: theme.spacing(1),
+          color: theme.palette.secondary.main,
+          backgroundColor: theme.palette.success.main,
         }}
       >
-        <Typography
-          component="h1"
-          variant="h3"
-          color="primary"
-          sx={{ textAlign: "center" }}
-        >
-          JuiceFinder
-        </Typography>
-        <Avatar
-          sx={{
-            margin: theme.spacing(1),
-            color: theme.palette.secondary.main,
-            backgroundColor: theme.palette.success.main,
-          }}
-        >
-          <OfflineBoltIcon />
-        </Avatar>
-        <div>
-          {errorMsg && (
-            <Box>
-              <Typography color="error">{errorMsg}</Typography>
-            </Box>
-          )}
-          <Box sx={{ fontWeight: "Bold", marginTop: theme.spacing(3) }}>
-            <Typography variant="h4">Account Information</Typography>
+        <OfflineBoltIcon />
+      </Avatar>
+      <div>
+        {errorMsg && (
+          <Box>
+            <Typography color="error">{errorMsg}</Typography>
           </Box>
-          <Typography>
-            <b>Email:</b> {currentUser.email}
-          </Typography>
-          {/* <Typography>
+        )}
+        <Box sx={{ fontWeight: "Bold", marginTop: theme.spacing(3) }}>
+          <Typography variant="h4">Account Information</Typography>
+        </Box>
+        <Typography>
+          <b>Email:</b> {currentUser.email}
+        </Typography>
+        {/* <Typography>
           <b>User ID:</b> {currentUser.uid}
         </Typography> */}
 
-          {vehicleInfo && (
-            <div style={{ marginTop: theme.spacing(3) }}>
-              <Box sx={{ fontWeight: "Bold" }}>
-                <Typography variant="h4">Saved Vehicle Information</Typography>
-              </Box>
-              {/* <Typography>
+        {vehicleInfo && (
+          <div style={{ marginTop: theme.spacing(3) }}>
+            <Box sx={{ fontWeight: "Bold" }}>
+              <Typography variant="h4">Saved Vehicle Information</Typography>
+            </Box>
+            {/* <Typography>
               <b>Vehicle ID:</b> {vehicleInfo.id}
             </Typography> */}
+            <Typography>
+              <b>Brand:</b> {vehicleInfo.brand}
+            </Typography>
+            <Typography>
+              <b>Type:</b> {vehicleInfo.vehicle_type}
+            </Typography>
+            <Typography>
+              <b>Model:</b> {vehicleInfo.model}
+            </Typography>
+            <Typography>
+              <b>Release Year:</b> {vehicleInfo.release_year}
+            </Typography>
+            {vehicleInfo.variant && (
               <Typography>
-                <b>Brand:</b> {vehicleInfo.brand}
+                <b>Variant:</b> {vehicleInfo.variant}
               </Typography>
+            )}
+            <Typography>
+              <b>Vehicle Type:</b> {vehicleInfo.type}
+            </Typography>
+            {vehicleInfo.usable_battery_size && (
               <Typography>
-                <b>Type:</b> {vehicleInfo.vehicle_type}
+                <b>Usable Battery Size:</b> {vehicleInfo.usable_battery_size}
               </Typography>
+            )}
+            {vehicleInfo.energy_consumption && (
               <Typography>
-                <b>Model:</b> {vehicleInfo.model}
+                <b>Energy Consumption:</b> {vehicleInfo.energy_consumption}
               </Typography>
-              <Typography>
-                <b>Release Year:</b> {vehicleInfo.release_year}
-              </Typography>
-              {vehicleInfo.variant && (
-                <Typography>
-                  <b>Variant:</b> {vehicleInfo.variant}
-                </Typography>
-              )}
-              <Typography>
-                <b>Vehicle Type:</b> {vehicleInfo.type}
-              </Typography>
-              {vehicleInfo.usable_battery_size && (
-                <Typography>
-                  <b>Usable Battery Size:</b> {vehicleInfo.usable_battery_size}
-                </Typography>
-              )}
-              {vehicleInfo.energy_consumption && (
-                <Typography>
-                  <b>Energy Consumption:</b> {vehicleInfo.energy_consumption}
-                </Typography>
-              )}
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        )}
+      </div>
 
-        <div style={{ marginTop: theme.spacing(1) }}>
-          <Button onClick={handleOpenPopup} variant="contained" color="primary">
-            Update Saved Vehicle
-          </Button>
-          <Dialog open={openPopup} onClose={handleClosePopup}>
-            <DialogTitle>
-              <Box sx={{ fontWeight: "Bold" }}>
-                <Typography variant="h4">Save a new vehicle</Typography>
+      <div style={{ marginTop: theme.spacing(1) }}>
+        <Button onClick={handleOpenPopup} variant="contained" color="primary">
+          Update Saved Vehicle
+        </Button>
+        <Dialog open={openPopup} onClose={handleClosePopup}>
+          <DialogTitle>
+            <Box sx={{ fontWeight: "Bold" }}>
+              <Typography variant="h4">Save a new vehicle</Typography>
+            </Box>
+          </DialogTitle>
+          <DialogContent>
+            {errorMsgPopup && (
+              <Box>
+                <Typography color="error">{errorMsgPopup}</Typography>
               </Box>
-            </DialogTitle>
-            <DialogContent>
-              {errorMsgPopup && (
+            )}
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                "& .MuiTextField-root": { m: 1, width: "25ch" },
+              }}
+            >
+              {/* Brand Text Field */}
+              <TextField
+                select
+                variant="outlined"
+                color="primary"
+                label="Brand"
+                value={brand}
+                onChange={(e) => setBrand(e.target.value)}
+              >
+                {Array.from(new Set(dataArray.map((item) => item.brand))).map(
+                  (option) => (
+                    <MenuItem key={option} value={option}>
+                      {option}
+                    </MenuItem>
+                  )
+                )}
+              </TextField>
+
+              {/* Model Text Field */}
+              <TextField
+                select
+                variant="outlined"
+                color="primary"
+                label="Model"
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+              >
+                {Array.from(
+                  new Set(
+                    dataArray
+                      .filter((item) => item.brand === brand)
+                      .map((item) => item.model)
+                  )
+                ).map((option) => (
+                  <MenuItem key={option} value={option}>
+                    {option}
+                  </MenuItem>
+                ))}
+              </TextField>
+
+              {/* Release Year Text Field */}
+              {Array.from(
+                new Set(
+                  dataArray
+                    .filter(
+                      (item) => item.brand === brand && item.model === model
+                    )
+                    .map((item) => item.release_year)
+                )
+              ).length > 0 && (
                 <Box>
-                  <Typography color="error">{errorMsgPopup}</Typography>
+                  <TextField
+                    select
+                    variant="outlined"
+                    color="primary"
+                    label="Release Year"
+                    value={parseFloat(releaseYear)}
+                    onChange={(e) => {
+                      setReleaseYear(e.target.value);
+                    }}
+                  >
+                    {Array.from(
+                      new Set(
+                        dataArray
+                          .filter(
+                            (item) =>
+                              item.brand === brand && item.model === model
+                          )
+                          .map((item) => parseInt(item.release_year, 10))
+                      )
+                    ).map((option) => (
+                      <MenuItem key={option} value={option}>
+                        {option}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                </Box>
+              )}
+              {/* Variant Text Field */}
+              {availableVariants[0] !== "" && (
+                <Box>
+                  <TextField
+                    select
+                    variant="outlined"
+                    color="primary"
+                    label="Variant"
+                    value={variant}
+                    onChange={(e) => setVariant(e.target.value)}
+                  >
+                    {availableVariants.map((option) => (
+                      <MenuItem key={option} value={option}>
+                        {option}
+                      </MenuItem>
+                    ))}
+                  </TextField>
                 </Box>
               )}
               <Box
                 sx={{
                   display: "flex",
-                  flexDirection: "column",
-                  "& .MuiTextField-root": { m: 1, width: "25ch" },
+                  justifyContent: "flex-end",
+                  alignItems: "flex-end",
+                  marginTop: "auto",
                 }}
               >
-                {/* Brand Text Field */}
-                <TextField
-                  select
-                  variant="outlined"
+                <Button
+                  variant="contained"
                   color="primary"
-                  label="Brand"
-                  value={brand}
-                  onChange={(e) => setBrand(e.target.value)}
+                  onClick={handleUpdateVehicle}
                 >
-                  {Array.from(new Set(dataArray.map((item) => item.brand))).map(
-                    (option) => (
-                      <MenuItem key={option} value={option}>
-                        {option}
-                      </MenuItem>
-                    )
-                  )}
-                </TextField>
-
-                {/* Model Text Field */}
-                <TextField
-                  select
-                  variant="outlined"
-                  color="primary"
-                  label="Model"
-                  value={model}
-                  onChange={(e) => setModel(e.target.value)}
-                >
-                  {Array.from(
-                    new Set(
-                      dataArray
-                        .filter((item) => item.brand === brand)
-                        .map((item) => item.model)
-                    )
-                  ).map((option) => (
-                    <MenuItem key={option} value={option}>
-                      {option}
-                    </MenuItem>
-                  ))}
-                </TextField>
-
-                {/* Release Year Text Field */}
-                {Array.from(
-                  new Set(
-                    dataArray
-                      .filter(
-                        (item) => item.brand === brand && item.model === model
-                      )
-                      .map((item) => item.release_year)
-                  )
-                ).length > 0 && (
-                  <Box>
-                    <TextField
-                      select
-                      variant="outlined"
-                      color="primary"
-                      label="Release Year"
-                      value={parseFloat(releaseYear)}
-                      onChange={(e) => {
-                        setReleaseYear(e.target.value);
-                      }}
-                    >
-                      {Array.from(
-                        new Set(
-                          dataArray
-                            .filter(
-                              (item) =>
-                                item.brand === brand && item.model === model
-                            )
-                            .map((item) => parseInt(item.release_year, 10))
-                        )
-                      ).map((option) => (
-                        <MenuItem key={option} value={option}>
-                          {option}
-                        </MenuItem>
-                      ))}
-                    </TextField>
-                  </Box>
-                )}
-                {/* Variant Text Field */}
-                {availableVariants[0] !== "" && (
-                  <Box>
-                    <TextField
-                      select
-                      variant="outlined"
-                      color="primary"
-                      label="Variant"
-                      value={variant}
-                      onChange={(e) => setVariant(e.target.value)}
-                    >
-                      {availableVariants.map((option) => (
-                        <MenuItem key={option} value={option}>
-                          {option}
-                        </MenuItem>
-                      ))}
-                    </TextField>
-                  </Box>
-                )}
-                <Box
-                  sx={{
-                    display: "flex",
-                    justifyContent: "flex-end",
-                    alignItems: "flex-end",
-                    marginTop: "auto",
-                  }}
-                >
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={handleUpdateVehicle}
-                  >
-                    Update Vehicle
-                  </Button>
-                </Box>
+                  Update Vehicle
+                </Button>
               </Box>
-            </DialogContent>
-          </Dialog>
-        </div>
-      </StyledContainer>
-    </>
+            </Box>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </StyledContainer>
   );
 }
 

--- a/client/src/settings/index.js
+++ b/client/src/settings/index.js
@@ -18,6 +18,7 @@ import OfflineBoltIcon from "@mui/icons-material/OfflineBolt";
 import { styled } from "@mui/system";
 import { useAuth } from "../auth/AuthContext";
 import config from "../config.json";
+import ResponsiveAppBar from "../common/AppBar";
 
 const StyledContainer = styled(Container)(() => ({
   display: "flex",
@@ -237,248 +238,251 @@ function Settings() {
   };
 
   return (
-    <StyledContainer
-      maxWidth="md"
-      sx={{
-        marginTop: theme.spacing(2),
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        backgroundColor: theme.palette.background.paper,
-        borderRadius: theme.shape.borderRadius,
-        paddingTop: theme.spacing(6),
-        paddingBottom: theme.spacing(10),
-        paddingLeft: theme.spacing(6),
-        paddingRight: theme.spacing(6),
-        boxShadow: theme.shadows[3],
-      }}
-    >
-      <Typography
-        component="h1"
-        variant="h3"
-        color="primary"
-        sx={{ textAlign: "center" }}
-      >
-        JuiceFinder
-      </Typography>
-      <Avatar
+    <>
+      <ResponsiveAppBar />
+      <StyledContainer
+        maxWidth="md"
         sx={{
-          margin: theme.spacing(1),
-          color: theme.palette.secondary.main,
-          backgroundColor: theme.palette.success.main,
+          marginTop: theme.spacing(2),
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          backgroundColor: theme.palette.background.paper,
+          borderRadius: theme.shape.borderRadius,
+          paddingTop: theme.spacing(6),
+          paddingBottom: theme.spacing(10),
+          paddingLeft: theme.spacing(6),
+          paddingRight: theme.spacing(6),
+          boxShadow: theme.shadows[3],
         }}
       >
-        <OfflineBoltIcon />
-      </Avatar>
-      <div>
-        {errorMsg && (
-          <Box>
-            <Typography color="error">{errorMsg}</Typography>
-          </Box>
-        )}
-        <Box sx={{ fontWeight: "Bold", marginTop: theme.spacing(3) }}>
-          <Typography variant="h4">Account Information</Typography>
-        </Box>
-        <Typography>
-          <b>Email:</b> {currentUser.email}
+        <Typography
+          component="h1"
+          variant="h3"
+          color="primary"
+          sx={{ textAlign: "center" }}
+        >
+          JuiceFinder
         </Typography>
-        {/* <Typography>
+        <Avatar
+          sx={{
+            margin: theme.spacing(1),
+            color: theme.palette.secondary.main,
+            backgroundColor: theme.palette.success.main,
+          }}
+        >
+          <OfflineBoltIcon />
+        </Avatar>
+        <div>
+          {errorMsg && (
+            <Box>
+              <Typography color="error">{errorMsg}</Typography>
+            </Box>
+          )}
+          <Box sx={{ fontWeight: "Bold", marginTop: theme.spacing(3) }}>
+            <Typography variant="h4">Account Information</Typography>
+          </Box>
+          <Typography>
+            <b>Email:</b> {currentUser.email}
+          </Typography>
+          {/* <Typography>
           <b>User ID:</b> {currentUser.uid}
         </Typography> */}
 
-        {vehicleInfo && (
-          <div style={{ marginTop: theme.spacing(3) }}>
-            <Box sx={{ fontWeight: "Bold" }}>
-              <Typography variant="h4">Saved Vehicle Information</Typography>
-            </Box>
-            {/* <Typography>
+          {vehicleInfo && (
+            <div style={{ marginTop: theme.spacing(3) }}>
+              <Box sx={{ fontWeight: "Bold" }}>
+                <Typography variant="h4">Saved Vehicle Information</Typography>
+              </Box>
+              {/* <Typography>
               <b>Vehicle ID:</b> {vehicleInfo.id}
             </Typography> */}
-            <Typography>
-              <b>Brand:</b> {vehicleInfo.brand}
-            </Typography>
-            <Typography>
-              <b>Type:</b> {vehicleInfo.vehicle_type}
-            </Typography>
-            <Typography>
-              <b>Model:</b> {vehicleInfo.model}
-            </Typography>
-            <Typography>
-              <b>Release Year:</b> {vehicleInfo.release_year}
-            </Typography>
-            {vehicleInfo.variant && (
               <Typography>
-                <b>Variant:</b> {vehicleInfo.variant}
+                <b>Brand:</b> {vehicleInfo.brand}
               </Typography>
-            )}
-            <Typography>
-              <b>Vehicle Type:</b> {vehicleInfo.type}
-            </Typography>
-            {vehicleInfo.usable_battery_size && (
               <Typography>
-                <b>Usable Battery Size:</b> {vehicleInfo.usable_battery_size}
+                <b>Type:</b> {vehicleInfo.vehicle_type}
               </Typography>
-            )}
-            {vehicleInfo.energy_consumption && (
               <Typography>
-                <b>Energy Consumption:</b> {vehicleInfo.energy_consumption}
+                <b>Model:</b> {vehicleInfo.model}
               </Typography>
-            )}
-          </div>
-        )}
-      </div>
-
-      <div style={{ marginTop: theme.spacing(1) }}>
-        <Button onClick={handleOpenPopup} variant="contained" color="primary">
-          Update Saved Vehicle
-        </Button>
-        <Dialog open={openPopup} onClose={handleClosePopup}>
-          <DialogTitle>
-            <Box sx={{ fontWeight: "Bold" }}>
-              <Typography variant="h4">Save a new vehicle</Typography>
-            </Box>
-          </DialogTitle>
-          <DialogContent>
-            {errorMsgPopup && (
-              <Box>
-                <Typography color="error">{errorMsgPopup}</Typography>
-              </Box>
-            )}
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: "column",
-                "& .MuiTextField-root": { m: 1, width: "25ch" },
-              }}
-            >
-              {/* Brand Text Field */}
-              <TextField
-                select
-                variant="outlined"
-                color="primary"
-                label="Brand"
-                value={brand}
-                onChange={(e) => setBrand(e.target.value)}
-              >
-                {Array.from(new Set(dataArray.map((item) => item.brand))).map(
-                  (option) => (
-                    <MenuItem key={option} value={option}>
-                      {option}
-                    </MenuItem>
-                  )
-                )}
-              </TextField>
-
-              {/* Model Text Field */}
-              <TextField
-                select
-                variant="outlined"
-                color="primary"
-                label="Model"
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-              >
-                {Array.from(
-                  new Set(
-                    dataArray
-                      .filter((item) => item.brand === brand)
-                      .map((item) => item.model)
-                  )
-                ).map((option) => (
-                  <MenuItem key={option} value={option}>
-                    {option}
-                  </MenuItem>
-                ))}
-              </TextField>
-
-              {/* Release Year Text Field */}
-              {Array.from(
-                new Set(
-                  dataArray
-                    .filter(
-                      (item) => item.brand === brand && item.model === model
-                    )
-                    .map((item) => item.release_year)
-                )
-              ).length > 0 && (
-                <Box>
-                  <TextField
-                    select
-                    variant="outlined"
-                    color="primary"
-                    label="Release Year"
-                    value={parseFloat(releaseYear)}
-                    onChange={(e) => {
-                      setReleaseYear(e.target.value);
-                    }}
-                  >
-                    {Array.from(
-                      new Set(
-                        dataArray
-                          .filter(
-                            (item) =>
-                              item.brand === brand && item.model === model
-                          )
-                          .map((item) => parseInt(item.release_year, 10))
-                      )
-                    ).map((option) => (
-                      <MenuItem key={option} value={option}>
-                        {option}
-                      </MenuItem>
-                    ))}
-                  </TextField>
-                </Box>
+              <Typography>
+                <b>Release Year:</b> {vehicleInfo.release_year}
+              </Typography>
+              {vehicleInfo.variant && (
+                <Typography>
+                  <b>Variant:</b> {vehicleInfo.variant}
+                </Typography>
               )}
-              {/* Variant Text Field */}
-              {availableVariants[0] !== "" && (
+              <Typography>
+                <b>Vehicle Type:</b> {vehicleInfo.type}
+              </Typography>
+              {vehicleInfo.usable_battery_size && (
+                <Typography>
+                  <b>Usable Battery Size:</b> {vehicleInfo.usable_battery_size}
+                </Typography>
+              )}
+              {vehicleInfo.energy_consumption && (
+                <Typography>
+                  <b>Energy Consumption:</b> {vehicleInfo.energy_consumption}
+                </Typography>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div style={{ marginTop: theme.spacing(1) }}>
+          <Button onClick={handleOpenPopup} variant="contained" color="primary">
+            Update Saved Vehicle
+          </Button>
+          <Dialog open={openPopup} onClose={handleClosePopup}>
+            <DialogTitle>
+              <Box sx={{ fontWeight: "Bold" }}>
+                <Typography variant="h4">Save a new vehicle</Typography>
+              </Box>
+            </DialogTitle>
+            <DialogContent>
+              {errorMsgPopup && (
                 <Box>
-                  <TextField
-                    select
-                    variant="outlined"
-                    color="primary"
-                    label="Variant"
-                    value={variant}
-                    onChange={(e) => setVariant(e.target.value)}
-                  >
-                    {availableVariants.map((option) => (
-                      <MenuItem key={option} value={option}>
-                        {option}
-                      </MenuItem>
-                    ))}
-                  </TextField>
+                  <Typography color="error">{errorMsgPopup}</Typography>
                 </Box>
               )}
               <Box
                 sx={{
                   display: "flex",
-                  justifyContent: "flex-end",
-                  alignItems: "flex-end",
-                  marginTop: "auto",
+                  flexDirection: "column",
+                  "& .MuiTextField-root": { m: 1, width: "25ch" },
                 }}
               >
-                <Button
-                  variant="contained"
+                {/* Brand Text Field */}
+                <TextField
+                  select
+                  variant="outlined"
                   color="primary"
-                  onClick={handleUpdateVehicle}
+                  label="Brand"
+                  value={brand}
+                  onChange={(e) => setBrand(e.target.value)}
                 >
-                  Update Vehicle
-                </Button>
-              </Box>
-            </Box>
-          </DialogContent>
-        </Dialog>
-      </div>
+                  {Array.from(new Set(dataArray.map((item) => item.brand))).map(
+                    (option) => (
+                      <MenuItem key={option} value={option}>
+                        {option}
+                      </MenuItem>
+                    )
+                  )}
+                </TextField>
 
-      <Button
-        variant="contained"
-        color="primary"
-        disabled={loading}
-        onClick={handleLogout}
-        sx={{ marginTop: theme.spacing(2) }}
-      >
-        Logout (for testing)
-      </Button>
-    </StyledContainer>
+                {/* Model Text Field */}
+                <TextField
+                  select
+                  variant="outlined"
+                  color="primary"
+                  label="Model"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                >
+                  {Array.from(
+                    new Set(
+                      dataArray
+                        .filter((item) => item.brand === brand)
+                        .map((item) => item.model)
+                    )
+                  ).map((option) => (
+                    <MenuItem key={option} value={option}>
+                      {option}
+                    </MenuItem>
+                  ))}
+                </TextField>
+
+                {/* Release Year Text Field */}
+                {Array.from(
+                  new Set(
+                    dataArray
+                      .filter(
+                        (item) => item.brand === brand && item.model === model
+                      )
+                      .map((item) => item.release_year)
+                  )
+                ).length > 0 && (
+                  <Box>
+                    <TextField
+                      select
+                      variant="outlined"
+                      color="primary"
+                      label="Release Year"
+                      value={parseFloat(releaseYear)}
+                      onChange={(e) => {
+                        setReleaseYear(e.target.value);
+                      }}
+                    >
+                      {Array.from(
+                        new Set(
+                          dataArray
+                            .filter(
+                              (item) =>
+                                item.brand === brand && item.model === model
+                            )
+                            .map((item) => parseInt(item.release_year, 10))
+                        )
+                      ).map((option) => (
+                        <MenuItem key={option} value={option}>
+                          {option}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  </Box>
+                )}
+                {/* Variant Text Field */}
+                {availableVariants[0] !== "" && (
+                  <Box>
+                    <TextField
+                      select
+                      variant="outlined"
+                      color="primary"
+                      label="Variant"
+                      value={variant}
+                      onChange={(e) => setVariant(e.target.value)}
+                    >
+                      {availableVariants.map((option) => (
+                        <MenuItem key={option} value={option}>
+                          {option}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  </Box>
+                )}
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "flex-end",
+                    alignItems: "flex-end",
+                    marginTop: "auto",
+                  }}
+                >
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleUpdateVehicle}
+                  >
+                    Update Vehicle
+                  </Button>
+                </Box>
+              </Box>
+            </DialogContent>
+          </Dialog>
+        </div>
+
+        <Button
+          variant="contained"
+          color="primary"
+          disabled={loading}
+          onClick={handleLogout}
+          sx={{ marginTop: theme.spacing(2) }}
+        >
+          Logout (for testing)
+        </Button>
+      </StyledContainer>
+    </>
   );
 }
 

--- a/client/src/statistics/index.js
+++ b/client/src/statistics/index.js
@@ -13,8 +13,6 @@ import OverviewTab from "./OverviewTab";
 import ElectricStationTab from "./ElectricStationTab";
 import EVFriendlinessTab from "./EVFriendlinessTab";
 
-import ResponsiveAppBar from "../common/AppBar";
-
 // functions required by MUI-tab component
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -78,7 +76,6 @@ function Statistics({ toggleTheme }) {
         flexDirection: "column",
       }}
     >
-      <ResponsiveAppBar />
       <Box
         sx={{
           backgroundColor: theme.palette.background.default,

--- a/client/src/statistics/index.js
+++ b/client/src/statistics/index.js
@@ -13,6 +13,8 @@ import OverviewTab from "./OverviewTab";
 import ElectricStationTab from "./ElectricStationTab";
 import EVFriendlinessTab from "./EVFriendlinessTab";
 
+import ResponsiveAppBar from "../common/AppBar";
+
 // functions required by MUI-tab component
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -76,6 +78,7 @@ function Statistics({ toggleTheme }) {
         flexDirection: "column",
       }}
     >
+      <ResponsiveAppBar />
       <Box
         sx={{
           backgroundColor: theme.palette.background.default,


### PR DESCRIPTION
Add layout which contains app bar (header) and footer

App bar:
- Shows logo and name
- Supports navigation between pages
- Has a user icon that contains a dropdown menu with the following functionalities:
    -  Navigating to the user settings page
    -  Logout

Footer:
- Shows copyright info
- Shows a list of contributors with corresponding links to personal websites/Github pages

Note: The logout testing button was removed from the user settings page because logout is now supported through the app bar.